### PR TITLE
Add: i18nによる日本語化対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,10 @@ gem 'jbuilder', '~> 2.7'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
+
+gem "bulma-rails"
 gem 'sorcery'
+gem 'rails-i18n'
 
 group :development, :test do
   # Debugger
@@ -43,9 +46,6 @@ group :development, :test do
   # Test
   gem 'rspec-rails'
   gem 'factory_bot_rails'
-
-  # CSS framework
-  gem "bulma-rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     rails_best_practices (1.22.1)
       activesupport
       code_analyzer (>= 0.5.2)
@@ -331,6 +334,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 4.1)
   rails (~> 6.1.4)
+  rails-i18n
   rails_best_practices
   rspec-rails
   rubocop

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,3 +1,5 @@
 class StaticPagesController < ApplicationController
+  skip_before_action :require_login, only: %i[top]
+
   def top; end
 end

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -3,6 +3,6 @@
     <%= image_tag 'logo.png', size: "200x130" %>
   <% end %>
 
-  <%= link_to 'login', login_path%>
+  <%= link_to (t 'defaults.login'), login_path%>
 <hr>
 </header>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,6 +3,6 @@
     <%= image_tag 'logo.png', size: "200x130" %>
   <% end %>
 
-  <%= link_to 'logout', logout_path, method: :delete %>
+  <%= link_to (t 'defaults.logout'), logout_path, method: :delete %>
 <hr>
 </header>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,23 +1,23 @@
 <div class="container">
   <div class="row">
     <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
-      <h1>ログイン</h1>
+      <h1><%= t '.title' %></h1>
       <%= form_with url: login_path, local: true do |f| %>
         <div class="form-group">
-          <%= f.label :email %>
+          <%= f.label :email, User.human_attribute_name(:email) %>
           <%= f.text_field :email, class: 'form-control' %>
         </div>
         <div class="form-group">
-          <%= f.label :password %>
+          <%= f.label :password, User.human_attribute_name(:password) %>
           <%= f.password_field :password, class: 'form-control' %>
         </div>
         <div class="actions">
-          <%= f.submit 'ログイン', class: 'btn btn-primary' %>
+          <%= f.submit (t 'defaults.login'), class: 'btn btn-primary' %>
         </div>
       <% end %>
       <div class='text-center'>
-        <%= link_to '登録ページへ', new_user_path %>
-        <a href="#">パスワードをお忘れの方はこちら</a>
+        <%= link_to (t '.to_register_page'), new_user_path %>
+        <a href="#"><%= t '.password_forget' %></a>
       </div>
     </div>
   </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
     <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
-      <h1>ユーザー登録</h1>
+      <h1><%= t '.title' %></h1>
       <%= form_with model: @user, local: true do |f| %>
         <div class="form-group">
           <%= f.label :nickname %>
@@ -19,10 +19,10 @@
           <%= f.label :password_confirmation %>
           <%= f.password_field :password_confirmation, class: 'form-control' %>
         </div>
-        <%= f.submit '登録', class: 'btn btn-primary' %>
+        <%= f.submit (t 'defaults.register'), class: 'btn btn-primary' %>
       <% end %>
       <div class='text-center'>
-        <%= link_to 'ログインページへ', login_path %>
+        <%= link_to (t '.to_login_page'), login_path %>
       </div>
     </div>
   </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,15 @@ module MachibugMap
     # Don't generate system test files.
     config.generators.system_tests = nil
 
+    # 翻訳ファイルをどこに配置するかの指定
+    config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}').to_s]
+
+    # デフォルトのlocaleを日本語(:ja)にする
+    config.i18n.default_locale = :ja
+
+    # デフォルトの時間を日本時間にする
+    config.time_zone = "Tokyo"
+
     config.generators do |g|
       g.skip_routes true
       g.assets false

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,10 @@
+ja:
+  activerecord:
+    models:
+      user: 'ユーザー'
+    attributes:
+      user:
+        name: 'ニックネーム'
+        email: 'メールアドレス'
+        password: 'パスワード'
+        password_confirmation: 'パスワード（確認）'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,14 @@
+ja:
+  defaults:
+    login: 'ログイン'
+    register: '登録'
+    logout: 'ログアウト'
+  users:
+    new:
+      title: 'ユーザー登録'
+      to_login_page: 'ログインページへ'
+  user_sessions:
+    new:
+      title: 'ログイン'
+      to_register_page: '登録ページへ'
+      password_forget: 'パスワードをお忘れの方はこちら'


### PR DESCRIPTION
## 概要
- gem 'rails-i18n'のインストール
- application.rbに以下の設定を追記
```
config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}').to_s]
config.i18n.default_locale = :ja
config.time_zone = "Tokyo"
```
- config/localesの配下にactiverecord、viewsフォルダを追加
- 上記で新規作成したフォルダの配下にja.ymlを配置
- 各ja.ymlに内容を記述
- i18nを使用した表記にviewファイルを修正

## 確認方法
- Gem を追加したので `bundle install` を実行してください