### PR TITLE
Fix: ログイン済ユーザーがログインページとユーザー登録ページにアクセスできないようにする

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,7 +1,11 @@
 class UserSessionsController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
 
-  def new; end
+  def new
+    if current_user
+      redirect_to root_path
+    end
+  end
 
   def create
     @user = login(params[:email], params[:password])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,9 @@ class UsersController < ApplicationController
 
   def new
     @user = User.new
+    if current_user
+      redirect_to root_path
+    end
   end
 
   def edit; end


### PR DESCRIPTION
## 概要
- users_controllerのnewアクションを修正
- user_sessions_controllerのnewアクションを修正

## 確認方法
- ログインした状態で、/loginと/users/newにアクセスできないことブラウザで確認してください。
