### PR TITLE
Add: フラッシュメッセージの設定を追加する。

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :require_login
+  add_flash_types :success, :info, :warning, :danger
 
   private
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,8 +3,7 @@ class PostsController < ApplicationController
     @posts = Post.all
   end
 
-  def show
-  end
+  def show; end
 
   def new
     @post = Post.new
@@ -13,14 +12,14 @@ class PostsController < ApplicationController
   def create
     @post = current_user.posts.build(post_params)
     if @post.save
-      redirect_to posts_path
+      redirect_to posts_path, success: t('.success')
     else
+      flash.now[:danger] = t('.fail')
       render :new
     end
   end
 
-  def edit
-  end
+  def edit; end
 
   private
 

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -2,9 +2,9 @@ class UserSessionsController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
 
   def new
-    # 現在ログイン中の時は、root_pathへリダイレクトする。
-    if current_user
-      redirect_to root_path
+    # 現在ログイン中の時は、rootへリダイレクトする。
+    if logged_in?
+      redirect_to root_url
     end
   end
 
@@ -12,14 +12,15 @@ class UserSessionsController < ApplicationController
     @user = login(params[:email], params[:password])
 
     if @user
-      redirect_back_or_to root_path
+      redirect_back_or_to root_path, success: t('.success')
     else
+      flash.now[:danger] = t('.fail')
       render :new
     end
   end
 
   def destroy
     logout
-    redirect_to root_path
+    redirect_to root_url, success: t('.success')
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,9 +10,9 @@ class UsersController < ApplicationController
 
   def new
     @user = User.new
-    # 現在ログイン中の時は、root_pathへリダイレクトする。
-    if current_user
-      redirect_to root_path
+    # 現在ログイン中の時は、rootへリダイレクトする。
+    if logged_in?
+      redirect_to root_url
     end
   end
 
@@ -21,33 +21,18 @@ class UsersController < ApplicationController
     if @user.save
       # ユーザー登録が成功したら、そのままログインが完了した状態になる。
       auto_login(@user)
-      redirect_to root_url
+      redirect_to root_url, success: t('.success')
     else
+      flash.now[:danger] = t('.fail')
       render :new
     end
   end
 
   def edit; end
 
-  def update
-    respond_to do |format|
-      if @user.update(user_params)
-        format.html { redirect_to @user, notice: "User was successfully updated." }
-        format.json { render :show, status: :ok, location: @user }
-      else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @user.errors, status: :unprocessable_entity }
-      end
-    end
-  end
+  def update; end
 
-  def destroy
-    @user.destroy
-    respond_to do |format|
-      format.html { redirect_to users_url, notice: "User was successfully destroyed." }
-      format.json { head :no_content }
-    end
-  end
+  def destroy; end
 
   private
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,7 @@
       <%= render 'shared/before_login_header' %>
     <% end %>
     <hr>
+    <%= render 'shared/flash_message' %>
     <%= yield %>
     <hr>
     <%= render 'shared/footer' %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -3,12 +3,10 @@
     <%= form.label :caption %>
     <%= form.text_area :caption %>
   </div>
-  
   <div class="field">
     <%= form.label :photo %>
     <%= form.file_field :photos, direct_upload: true, multiple: true %>
   </div>
-  
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,5 +1,9 @@
-<h1>新規投稿</h1>
-
-<%= render 'form', post: @post %>
-
-<%= link_to 'Back', posts_path %>
+<div class="container">
+  <div class="row">
+    <div class="col-lg-8 offset-lg-2">
+      <h1><%= t('.title') %></h1>
+      <%= render 'form', { post: @post } %>
+      <%= link_to 'Back', posts_path %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -23,7 +23,7 @@
           <% end %>
         </div>
         <div class="navbar-item">
-          <%= link_to '投稿', new_post_path%>
+          <%= link_to (t 'defaults.post'), new_post_path%>
         </div>
         <div class="navbar-item">
           <%= link_to (t 'defaults.login'), login_path%>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,11 @@
+<% flash.each do |message_type, message| %>
+  <div class="notification is-<%= message_type %> is-light"><%= message %><button class="delete"></button></div>
+<% end %>
+
+<script>
+for (const element of document.querySelectorAll('.notification > .delete')) {
+    element.addEventListener('click', e => {
+        e.target.parentNode.classList.add('is-hidden');
+    });
+}
+</script>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -23,7 +23,7 @@
           <% end %>
         </div>
         <div class="navbar-item">
-          <%= link_to '投稿', new_post_path%>
+          <%= link_to (t 'defaults.post'), new_post_path%>
         </div>
         <div class="navbar-item">
           <%= link_to (t 'defaults.logout'), logout_path, method: :delete %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -12,3 +12,6 @@ ja:
       title: 'ログイン'
       to_register_page: '登録ページへ'
       password_forget: 'パスワードをお忘れの方はこちら'
+  posts:
+    new:
+      title: '新規投稿'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -8,11 +8,22 @@ ja:
     new:
       title: 'ユーザー登録'
       to_login_page: 'ログインページへ'
+    create:
+      success: 'ユーザー登録が完了しました'
+      fail: 'ユーザー登録に失敗しました'
   user_sessions:
     new:
       title: 'login'
       to_register_page: '登録ページへ'
       password_forget: 'パスワードをお忘れの方はこちら'
+    create:
+      success: 'ログインしました'
+      fail: 'ログインに失敗しました'
+    destroy:
+      success: 'ログアウトしました'
   posts:
     new:
       title: 'post'
+    create:
+      success: '街バグの投稿が完了しました'
+      fail: '投稿に失敗しました'      

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,17 +1,18 @@
 ja:
   defaults:
-    login: 'ログイン'
-    register: '登録'
-    logout: 'ログアウト'
+    login: 'login'
+    register: 'submit'
+    logout: 'logout'
+    post: 'post'
   users:
     new:
       title: 'ユーザー登録'
       to_login_page: 'ログインページへ'
   user_sessions:
     new:
-      title: 'ログイン'
+      title: 'login'
       to_register_page: '登録ページへ'
       password_forget: 'パスワードをお忘れの方はこちら'
   posts:
     new:
-      title: '新規投稿'
+      title: 'post'


### PR DESCRIPTION
## 概要
以下の場合に、フラッシュメッセージを表示できるようにいたしました。
- ユーザーの新規登録成功/失敗時
- ログインの成功/失敗時
- 投稿の成功/失敗時

## 確認方法
以下のフラッシュメッセージが表示されることをご確認ください。
- ログイン成功時・・・「ログインしました」
- ログイン失敗時・・・「ログインに失敗しました」
- ログアウト時・・・「ログアウトしました」
- ユーザー登録時・・・「ユーザー登録が完了しました」
- ユーザー登録失敗時・・・「ユーザー登録に失敗しました」
- 新規投稿時・・・「街バグの投稿が完了しました」
- 新規投稿失敗時・・・「投稿に失敗しました」