### PR TITLE
Add: postsモデルの翻訳を追加

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,5 @@
 class Post < ApplicationRecord
-  validates :photos, attached: true
+  validates :photos, attached: { message: 'を選択してください。' }
 
   belongs_to :user
   has_many_attached :photos

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -8,3 +8,5 @@ ja:
         email: 'メールアドレス'
         password: 'パスワード'
         password_confirmation: 'パスワード（確認）'
+      post:
+        photos: '画像ファイル'


### PR DESCRIPTION
## 概要
post.rb　を以下の通り修正し、カスタムエラーメッセージを追加
- 修正前
```
validates :photos, attached: true
```
- 修正後
```
validates :photos, attached: { message: "を選択してください。" }
```

config/locales/ativerecord/ja.yml　に以下の翻訳を追加
```
post:
  photos: '画像ファイル'
```

## 確認方法
rails serverを起動して、ブラウザで新規投稿をした際に、ファイルが未選択の場合は
「画像ファイルを選択してください。」と表示されることをご確認ください。