### PR TITLE
Fix: フォームのレイアウトを調整。

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,7 +38,19 @@ hr {
   background-color: #707070;
 }
 
+// リンクが青色にならないように色を指定(すべてのリンクに適用)
 .linkcolor {
   text-decoration: none;
   color: #707070; 
+}
+
+// リンクが青色にならないように色を指定(プロフィール画面のボタンに適用)
+.linkwhite {
+  text-decoration: none;
+  color: #FFFFFF; 
+}
+
+// マウスオーバーした際に、リンク色が変わらないように色を指定(プロフィール画面のボタンに適用)
+.linkwhite:hover {
+  color: #FFFFFF;
 }

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,14 +1,15 @@
 <%= form_with model: @post, local: true do |f| %>
-  <%= render 'shared/error_messages', object: f.object %>
+<%= render 'shared/error_messages', object: f.object %>
   <div class="field">
-    <%= f.label :caption %>
-    <%= f.text_area :caption %>
+    <%= f.label :caption, class: 'label', class: 'has-text-weight-light' %>
+    <%= f.text_area :caption, class: 'textarea', placeholder: 'キャプションを入力してください。' %>
   </div>
   <div class="field">
-    <%= f.label :photo %>
+    <%= f.label :photo, class: 'label', class: 'has-text-weight-light' %><br>
     <%= f.file_field :photo, direct_upload: true, multiple: true %>
+    <p class="help is-info">必須</p>
   </div>
-  <div class="actions">
-    <%= f.submit (t 'defaults.register') %>
+  <div class="has-text-centered mt-5">
+    <%= f.submit (t 'defaults.register'), class: 'button is-dark' %>
   </div>
 <% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,5 +1,10 @@
-<div class="container">
-  <h1 class="title"><%= t('.title') %></h1>
-  <%= render 'form', { post: @post } %>
-  <%= link_to 'Back', posts_path, {class: "linkcolor"} %>
-</div>
+<section class="section">
+  <div class="container">
+    <div class="columns is-mobile is-vcentered">
+      <div class="column is-half is-offset-one-quarter">
+        <h1 class="title has-text-centered"><%= t '.title' %></h1>
+        <%= render 'form', { post: @post } %>
+      </div> 
+    </div>
+  </div>
+</section>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,27 +1,31 @@
-<div class="container">
-  <div class="row">
-    <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
-      <h1 class="title"><%= t '.title' %></h1>
-      <%= form_with model: @user, url: profile_path, local: true do |f| %>
-      <%= render 'shared/error_messages', object: f.object %>
-        <div class="form-group">
-          <%= f.label :name %>
-          <%= f.text_field :name, class: 'form-control' %>
-        </div>
-        <div class="form-group">
-          <%= f.label :email %>
-          <%= f.email_field :email, class: 'form-control' %>
-        </div>
-        <div class="form-group">
-          <%= f.label :'password' %>
-          <%= f.password_field :password, class: 'form-control' %>
-        </div>
-        <div class="form-group">
-          <%= f.label :password_confirmation %>
-          <%= f.password_field :password_confirmation, class: 'form-control' %>
-        </div>
-        <%= f.submit (t 'defaults.update'), class: 'btn btn-primary' %>
-      <% end %>
+<section class="section">
+  <div class="container">
+    <div class="columns is-mobile is-vcentered">
+      <div class="column is-half is-offset-one-quarter">
+        <h1 class="title has-text-centered"><%= t '.title' %></h1>
+        <%= form_with model: @user, url: profile_path, local: true do |f| %>
+        <%= render 'shared/error_messages', object: f.object %>
+          <div class="field">
+            <%= f.label :name, class: 'label', class: 'has-text-weight-light' %>
+            <%= f.text_field :name, class: 'input' %>
+          </div>
+          <div class="field">
+            <%= f.label :email, class: 'label', class: 'has-text-weight-light' %>
+            <%= f.email_field :email, class: 'input' %>
+          </div>
+          <div class="field">
+            <%= f.label :password, class: 'label', class: 'has-text-weight-light' %>
+            <%= f.password_field :password, class: 'input' %>
+          </div>
+          <div class="field">
+            <%= f.label :password_confirmation, class: 'label', class: 'has-text-weight-light' %>
+            <%= f.password_field :password_confirmation, class: 'input' %>
+          </div>
+          <div class="has-text-centered mt-5">
+            <%= f.submit (t 'defaults.update'), class: 'button is-dark' %>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
-</div>
+</section>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,23 +1,25 @@
-<div class="container">
-    <div class="has-text-centered">
-      <h1 class="title"><%= t('.title') %></h1>
+<section class="section">
+  <div class="container">
+    <div class="columns is-mobile is-vcentered">
+      <div class="column is-half is-offset-one-quarter">
+        <h1 class="title has-text-centered"><%= t '.title' %></h1>
+        <table class="table has-centered">
+          <tr>
+            <th>email address</th>
+            <td><%= current_user.email %></td>
+          </tr>
+          <tr>
+            <th>name</th>
+            <td><%= current_user.name %></td>
+          </tr>
+        </table>
+        <div class="has-text-centered mt-2">
+          <button class="button is-dark"><%= link_to('edit profile', edit_profile_path, class: 'linkwhite') %></button>
+        </div>
+        <div class="has-text-centered mt-2">
+          <%= link_to('退会', users_path(current_user), { method: :delete, data: { confirm: '退会してもよろしいですか?' }, class: 'linkcolor'}) %>
+        </div>
+      </div> 
     </div>
-    <div class="column is-3 is-offset-4">
-      <table class="table">
-        <tr>
-          <th>email address</th>
-          <td><%= current_user.email %></td>
-        </tr>
-        <tr>
-          <th>name</th>
-          <td><%= current_user.name %></td>
-        </tr>
-      </table>
-    </div>
-    <div class="has-text-centered">
-      <button class="button is-small"><%= link_to 'edit profile', edit_profile_path %></button>
-    </div>
-    <div class="has-text-centered is-size-7">
-      <%= link_to('退会', users_path(current_user), { method: :delete, data: { confirm: '退会してもよろしいですか?' }, class: 'linkcolor'}) %>
-    </div>
-</div>
+  </div>
+</section>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,6 +1,6 @@
 <header>
   <nav class="navbar" role="navigation" aria-label="main navigation">
-    <div class="navbar-brand ml-5">
+    <div class="navbar-brand ml-5 mt-5">
       <%= link_to root_path do %>
         <%= image_tag "logo.png", size: "200x130" %>
       <% end %>
@@ -15,8 +15,8 @@
         </div>
       </div>
     </div>
-    <div id="navbarBasicExample" class="navbar-menu">
-      <div class="navbar-end mr-5">
+    <div id="navbarBasicExample" class="navbar-menu mt-5 mr-5">
+      <div class="navbar-end">
         <div>
           <%= link_to '#' do %>
             <%= image_tag "bugchan.png", size: "60x100" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <header>
   <nav class="navbar" role="navigation" aria-label="main navigation">
-    <div class="navbar-brand ml-5">
+    <div class="navbar-brand ml-5 mt-5">
       <%= link_to root_path do %>
         <%= image_tag "logo.png", size: "200x130" %>
       <% end %>
@@ -15,8 +15,8 @@
         </div>
       </div>
     </div>
-    <div id="navbarBasicExample" class="navbar-menu">
-      <div class="navbar-end mr-5">
+    <div id="navbarBasicExample" class="navbar-menu mt-5 mr-5">
+      <div class="navbar-end">
         <div>
           <%= link_to '#' do %>
             <%= image_tag 'bugchan.png', size: '60x100' %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,24 +1,28 @@
-<div class="container">
-  <div class="row">
-    <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
-      <h1 class="title"><%= t '.title' %></h1>
-      <%= form_with url: login_path, local: true do |f| %>
-        <div class="form-group">
-          <%= f.label :email, User.human_attribute_name(:email) %>
-          <%= f.text_field :email, class: 'form-control' %>
+<section class="section">
+  <div class="container">
+    <div class="columns is-mobile is-vcentered">
+      <div class="column is-half is-offset-one-quarter">
+        <h1 class="title has-text-centered mt-6"><%= t '.title' %></h1>
+        <%= form_with url: login_path, local: true do |f| %>
+          <div class="field">
+            <%= f.label :email, User.human_attribute_name(:email), class: 'label', class: 'has-text-weight-light' %>
+            <%= f.text_field :email, class: 'input' %>
+          </div>
+          <div class="field">
+            <%= f.label :password, User.human_attribute_name(:password), class: 'label', class: 'has-text-weight-light' %>
+            <%= f.password_field :password, class: 'input' %>
+          </div>
+          <div class="has-text-centered mt-5">
+            <%= f.submit (t 'defaults.login'), class: 'button is-dark' %>
+          </div>
+        <% end %>
+        <div class="has-text-centered mt-5">
+          <%= link_to((t '.to_register_page'), new_user_path, {class: "linkcolor"}) %>
         </div>
-        <div class="form-group">
-          <%= f.label :password, User.human_attribute_name(:password) %>
-          <%= f.password_field :password, class: 'form-control' %>
+        <div class="has-text-centered mb-6">
+          <%= link_to((t '.password_forget'), '#', {class: "linkcolor"}) %>
         </div>
-        <div class="actions">
-          <%= f.submit (t 'defaults.login') %>
-        </div>
-      <% end %>
-      <div class='text-center'>
-        <%= link_to((t '.to_register_page'), new_user_path, {class: "linkcolor"}) %>
-        <%= link_to((t '.password_forget'), '#', {class: "linkcolor"}) %>
       </div>
     </div>
   </div>
-</div>
+</section>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,30 +1,37 @@
-<div class="container">
-  <div class="row">
-    <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
-      <h1 class="title"><%= t '.title' %></h1>
-      <%= form_with model: @user, local: true do |f| %>
-      <%= render 'shared/error_messages', object: f.object %>
-        <div class="form-group">
-          <%= f.label :name %>
-          <%= f.text_field :name, class: 'form-control' %>
+<section class="section">
+  <div class="container">
+    <div class="columns is-mobile is-vcentered">
+      <div class="column is-half is-offset-one-quarter">
+        <h1 class="title has-text-centered"><%= t '.title' %></h1>
+        <%= form_with model: @user, local: true do |f| %>
+        <%= render 'shared/error_messages', object: f.object %>
+          <div class="field">
+            <%= f.label :name, class: 'label', class: 'has-text-weight-light' %>
+            <%= f.text_field :name, class: 'input', placeholder: 'bugchan' %>
+            <p class="help is-info">必須</p>
+          </div>
+          <div class="field">
+            <%= f.label :email, class: 'label', class: 'has-text-weight-light' %>
+            <%= f.email_field :email, class: 'input', placeholder: 'machibug@example.com' %>
+            <p class="help is-info">必須</p>
+          </div>
+          <div class="field">
+            <%= f.label :password, class: 'label', class: 'has-text-weight-light' %>
+            <%= f.password_field :password, class: 'input' %>
+            <p class="help is-info">必須 半角英数8文字以上</p>
+          </div>
+          <div class="field">
+            <%= f.label :password_confirmation, class: 'label', class: 'has-text-weight-light' %>
+            <%= f.password_field :password_confirmation, class: 'input' %>
+          </div>
+          <div class="has-text-centered mt-5">
+            <%= f.submit (t 'defaults.register'), class: 'button is-dark' %>
+          </div>
+        <% end %>
+        <div class="has-text-centered mt-2">
+          <%= link_to((t '.to_login_page'), login_path, {class: 'linkcolor'}) %>
         </div>
-        <div class="form-group">
-          <%= f.label :email %>
-          <%= f.email_field :email, class: 'form-control' %>
-        </div>
-        <div class="form-group">
-          <%= f.label :password %>
-          <%= f.password_field :password, class: 'form-control' %>
-        </div>
-        <div class="form-group">
-          <%= f.label :password_confirmation %>
-          <%= f.password_field :password_confirmation, class: 'form-control' %>
-        </div>
-        <%= f.submit (t 'defaults.register') %>
-      <% end %>
-      <div class='text-center'>
-        <%= link_to((t '.to_login_page'), login_path, {class: 'linkcolor'}) %>
-      </div>
+      </div> 
     </div>
   </div>
-</div>
+</section>


### PR DESCRIPTION
## 概要
- 以下のフォームのレイアウトを調整しました。
    - 新規投稿フォーム
    - ユーザー登録フォーム
    - プロフィール編集フォーム
    - ログインフォーム

- 以下も気になった箇所(余白など)があったので、調整しました。
    - リンクカラー
    - ヘッダーの余白
    - プロフィール詳細画面のレイアウト

## 確認方法
rails serverを起動して、ブラウザ上でご確認ください。

## チェックリスト
- [x] Lint のチェックをパスした

## コメント
プロフィール詳細画面のレイアウトは、調整が十分でないので、
また後日改めて調整を行いたいと思っています。
