### PR TITLE
Add: spotsモデルを追加

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,5 +2,6 @@ class Post < ApplicationRecord
   validates :photos, attached: { message: 'を選択してください。' }
 
   belongs_to :user
+  has_one :spot
   has_many_attached :photos
 end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,0 +1,3 @@
+class Spot < ApplicationRecord
+  belongs_to :post
+end

--- a/db/migrate/20220107121745_create_spots.rb
+++ b/db/migrate/20220107121745_create_spots.rb
@@ -1,0 +1,12 @@
+class CreateSpots < ActiveRecord::Migration[6.1]
+  def change
+    create_table :spots do |t|
+      t.string :address
+      t.float :latitude
+      t.float :longitude
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_23_125716) do
+ActiveRecord::Schema.define(version: 2022_01_07_121745) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,16 @@ ActiveRecord::Schema.define(version: 2021_12_23_125716) do
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
+  create_table "spots", force: :cascade do |t|
+    t.string "address"
+    t.float "latitude"
+    t.float "longitude"
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_spots_on_post_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", null: false
@@ -66,4 +76,5 @@ ActiveRecord::Schema.define(version: 2021_12_23_125716) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "posts", "users"
+  add_foreign_key "spots", "posts"
 end


### PR DESCRIPTION
## 概要
- spotsモデルの雛形を作成
- データベースにテーブルを追加
- postsモデルにアソシエーションを追加

## 確認方法
- テーブルを追加したので `bundle exec rails db:migrate` を実行してください。

## チェックリスト
- [x] Lint のチェックをパスした