### PR TITLE
Fix: 新規投稿フォームからPostモデルと関連のあるSpotテーブルのaddressカラム(住所のカラム)をまとめて投稿できるように修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,6 @@
 class PostsController < ApplicationController
+  before_action :set_post, only: %i[show edit update destroy]
+
   def index
     @posts = Post.all
   end
@@ -7,12 +9,13 @@ class PostsController < ApplicationController
 
   def new
     @post = Post.new
+    @post.build_spot
   end
 
   def create
     @post = current_user.posts.build(post_params)
     if @post.save
-      redirect_to posts_path, success: t('.success')
+      redirect_to posts_url, success: t('.success')
     else
       flash.now[:danger] = t('.fail')
       render :new
@@ -21,9 +24,28 @@ class PostsController < ApplicationController
 
   def edit; end
 
+  def update
+    if @post.update(post_params)
+      redirect_to @post, success: t('.success')
+    else
+      flash.now[:danger] = t('.fail')
+      render :edit
+    end     
+  end
+
+  def destroy
+    @post.destroy
+    redirect_to posts_url, success: t('.success') 
+  end
+
   private
 
+  def set_post
+    @post = Post.find(params[:id])
+  end
+
   def post_params
-    params.require(:post).permit(:caption, :address, photos: [])
+  #  params.require(:post).permit(:caption, :address, photos: [])
+    params.require(:post).permit(:caption, :address, photos: [], spot_attributes: [:id, :address]).merge(user_id: current_user.id)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,6 +2,10 @@ class Post < ApplicationRecord
   validates :photos, attached: { message: 'を選択してください。' }
 
   belongs_to :user
-  has_one :spot
+  # postのレコードを削除したときに紐付いていたspotを同時に削除
+  has_one :spot, dependent: :destroy
+  # ２つのモデルがアソシエーションで結びついている時、２つまとめてレコードを投稿・更新できるRailsメソッド
+  # コントローラでの記述と組み合わせて使う
+  accepts_nested_attributes_for :spot
   has_many_attached :photos
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -6,8 +6,10 @@
     <p class="help is-info">必須</p>
   </div>
   <div class="field">
-    <%= f.label :address, class: 'label', class: 'has-text-weight-light' %>
-    <%= f.text_field :address, class: 'input', placeholder: 'e.g. 吉祥寺駅' %>
+    <%= f.fields_for :spot do |s| %>
+      <%= s.label :address, class: 'label', class: 'has-text-weight-light' %>
+      <%= s.text_field :address, class: 'input', placeholder: 'e.g. 吉祥寺駅' %>
+    <% end %>
   </div>
   <div class="field">
     <%= f.label :caption, class: 'label', class: 'has-text-weight-light' %>
@@ -17,3 +19,4 @@
     <%= f.submit (t 'defaults.register'), class: 'button is-dark' %>
   </div>
 <% end %>
+  

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,2 +1,6 @@
-<h1>Posts#edit</h1>
-<p>Find me in app/views/posts/edit.html.erb</p>
+<h1>投稿編集</h1>
+
+<%= render 'form', post: @post %>
+
+<%= link_to 'Show', @post %> |
+<%= link_to 'Back', posts_path %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,2 +1,23 @@
-<h1>Posts#index</h1>
-<p>Find me in app/views/posts/index.html.erb</p>
+<table>
+  <thead>
+    <tr>
+      <th>Caption</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @posts.each do |post| %>
+      <tr>
+        <td><%= post.caption %></td>
+        <td><%= link_to 'Show', post %></td>
+        <td><%= link_to 'Edit', edit_post_path(post) %></td>
+        <td><%= link_to 'Destroy', post, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Post', new_post_path %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,2 +1,20 @@
-<h1>Posts#show</h1>
-<p>Find me in app/views/posts/show.html.erb</p>
+<p>
+  <strong>Caption:</strong>
+  <%= @post.caption %>
+</p>
+<p>
+  <strong>Address:</strong>
+  <%= @post.spot.address %>
+</p>
+
+<p>
+  <strong>Photos:</strong>
+  <% if @post.photos.attached? %>
+    <% @post.photos.each do |photo| %>
+      <%= image_tag photo.variant(resize_to_limit: [100, 100]) %>
+    <% end %>
+  <% end %>
+</p>
+
+<%= link_to 'Edit', edit_post_path(@post) %> |
+<%= link_to 'Back', posts_path %>


### PR DESCRIPTION
## 概要
- 関連のあるPostモデル(親)とSpotモデル(子)のレコードを一度に投稿できるように、以下の内容を変更しました。
  - posts_controller
  ⇨ newアクションに.buildメソッドを追加
  - posts/_form.html.erb
  ⇨ addressのフォームをfields_forメソッドを使った記述に変更
  - post.rb
  ⇨ accepts_nested_attributes_forメソッドを追加
- 仮で、投稿一覧・詳細・編集画面を追加
- 仮で、投稿削除機能を追加

## コメント
投稿一覧・詳細・編集画面は仮のものなので、後日作成しなおす予定です。
