### PR TITLE
Fix: 投稿詳細画面のレイアウトを微調整

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,4 @@
 class PostsController < ApplicationController
-
   def index
     @posts = Post.all
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -30,12 +30,12 @@ class PostsController < ApplicationController
     else
       flash.now[:danger] = t('.fail')
       render :edit
-    end     
+    end
   end
 
   def destroy
     @post.destroy
-    redirect_to posts_url, success: t('.success') 
+    redirect_to posts_url, success: t('.success')
   end
 
   private
@@ -45,7 +45,6 @@ class PostsController < ApplicationController
   end
 
   def post_params
-  #  params.require(:post).permit(:caption, :address, photos: [])
-    params.require(:post).permit(:caption, :address, photos: [], spot_attributes: [:id, :address]).merge(user_id: current_user.id)
+    params.require(:post).permit(:caption, :address, photos: [], spot_attributes: %i[id address]).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,11 +1,12 @@
 class PostsController < ApplicationController
-  before_action :set_post, only: %i[show edit update destroy]
 
   def index
     @posts = Post.all
   end
 
-  def show; end
+  def show
+    @post = Post.find(params[:id])
+  end
 
   def new
     @post = Post.new
@@ -22,9 +23,12 @@ class PostsController < ApplicationController
     end
   end
 
-  def edit; end
+  def edit
+    @post = current_user.posts.find(params[:id])
+  end
 
   def update
+    @post = current_user.posts.find(params[:id])
     if @post.update(post_params)
       redirect_to @post, success: t('.success')
     else
@@ -34,15 +38,12 @@ class PostsController < ApplicationController
   end
 
   def destroy
+    @post = current_user.posts.find(params[:id])
     @post.destroy
     redirect_to posts_url, success: t('.success')
   end
 
   private
-
-  def set_post
-    @post = Post.find(params[:id])
-  end
 
   def post_params
     params.require(:post).permit(:caption, :address, photos: [], spot_attributes: %i[id address]).merge(user_id: current_user.id)

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,6 +1,13 @@
-<h1>投稿編集</h1>
-
-<%= render 'form', post: @post %>
-
-<%= link_to 'Show', @post %> |
-<%= link_to 'Back', posts_path %>
+<section class="section">
+  <div class="container">
+    <div class="columns is-mobile is-vcentered">
+      <div class="column is-half is-offset-one-quarter">
+        <h1 class="title has-text-centered"><%= t '.title' %></h1>
+          <%= render 'form', post: @post %>
+      </div>
+    </div>
+  </div>
+  <div class="has-text-centered mt-2">
+    <%= link_to('Back', posts_path, {class: 'linkcolor'}) %>
+  </div>
+</section>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,20 +1,25 @@
-<p>
-  <strong>Caption:</strong>
-  <%= @post.caption %>
-</p>
-<p>
-  <strong>Address:</strong>
-  <%= @post.spot.address %>
-</p>
-
-<p>
-  <strong>Photos:</strong>
-  <% if @post.photos.attached? %>
-    <% @post.photos.each do |photo| %>
-      <%= image_tag photo.variant(resize_to_limit: [100, 100]) %>
-    <% end %>
-  <% end %>
-</p>
-
-<%= link_to 'Edit', edit_post_path(@post) %> |
-<%= link_to 'Back', posts_path %>
+<section class="section">
+  <div class="container">
+    <p>
+      <% if @post.photos.attached? %>
+        <% @post.photos.each do |photo| %>
+          <%= image_tag photo.variant(resize_to_limit: [300, 200]) %>
+        <% end %>
+      <% end %>
+    </p>
+    <p>
+    <strong>Nickname:</strong>
+    <%= @post.user.name %>
+    </p>
+    <p>
+      <strong>Caption:</strong>
+      <%= @post.caption %>
+    </p>
+    <p>
+      <strong>Address:</strong>
+      <%= @post.spot.address %>
+    </p>
+    <%= link_to 'Edit', edit_post_path(@post) %> |
+    <%= link_to 'Back', posts_path %>
+  </div>
+</section>


### PR DESCRIPTION
## 概要
- 投稿詳細画面のレイアウトを微調整
- 投稿詳細画面に投稿者名が表示されるように修正
- 投稿編集画面のレイアウトも微調整
- posts_controllerのedit/update/destroyアクションについて、
投稿を取得する方法をcurrent_userのものだけに限定

## チェックリスト
- [x] Lint のチェックをパスした