### PR TITLE
Add: コメント機能の追加

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,16 @@
+class CommentsController < ApplicationController
+  def create
+    comment = current_user.comments.build(comment_params)
+    if comment.save
+      redirect_to post_path(comment.post), success: t('.success')
+    else
+      redirect_to post_path(comment.post), danger: t('.fail')
+    end
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:body).merge(post_id: params[:post_id])
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,10 +1,13 @@
 class PostsController < ApplicationController
   def index
-    @posts = Post.all
+    # @posts = Post.all.order(created_at: :desc)
+    @posts = Post.includes(:user).order(created_at: :desc)
   end
 
   def show
     @post = Post.find(params[:id])
+    @comment = Comment.new
+    @comments = @post.comments.includes(:user).order(created_at: :desc)
   end
 
   def new

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,7 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+  
+  # bodyカラムは、必須項目であり、最長65535字までというバリデーション。
+  validates :body, presence: true, length: { maximum: 65_535 }
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,7 +1,7 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :post
-  
+
   # bodyカラムは、必須項目であり、最長65535字までというバリデーション。
   validates :body, presence: true, length: { maximum: 65_535 }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -8,4 +8,6 @@ class Post < ApplicationRecord
   # コントローラでの記述と組み合わせて使う
   accepts_nested_attributes_for :spot
   has_many_attached :photos
+  # postのレコードを削除したときに紐付いているcommentsも同時に削除する
+  has_many :comments, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,4 +20,8 @@ class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   # Userを削除したときに紐付いているcommentsも同時に削除する。
   has_many :comments, dependent: :destroy
+
+  def own?(object)
+    id == object.user_id
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,5 +16,8 @@ class User < ApplicationRecord
   validates :password, confirmation: true, length: { minimum: 8 }, format: { with: VALID_PASSWORD_REGEX, message: '半角英数字のみ使用可能です' }, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 
-  has_many :posts
+  # Userを削除したときに紐付いているpostsも同時に削除する。
+  has_many :posts, dependent: :destroy
+  # Userを削除したときに紐付いているcommentsも同時に削除する。
+  has_many :comments, dependent: :destroy
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,0 +1,21 @@
+<tr>
+  <td style="width: 650px">
+    <%= comment.user.name %>
+    <div>
+      <%= simple_format(comment.body) %>
+    </div>
+  </td>
+
+  <% if current_user.own?(comment) %>
+    <td>
+      <%= link_to "#", method: :get do %>
+        <%= icon 'fa', 'pen' %>
+      <% end %>
+      <%= link_to "#", method: :delete do %>
+        <%= icon 'fas', 'trash' %>
+      <% end %>
+    </td>
+  <% else %>
+    <td></td>
+  <% end %>
+</tr>

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -1,0 +1,5 @@
+<div class="container mt-6">
+  <table class="table">
+    <%= render comments %>
+  </table>
+</div>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,0 +1,12 @@
+<div class="container mt-6">
+  <%= form_with model: comment, url: [post, comment], local: true do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+    <div class="field">
+      <%= f.label :body, class: 'label', class: 'has-text-weight-light' %>
+      <%= f.text_area :body, class: 'textarea', placeholder: 'コメントを入力してください。' %>
+    </div>
+    <div>
+      <%= f.submit (t 'defaults.register'), class: 'button is-dark' %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -2,7 +2,9 @@
 <table>
   <thead>
     <tr>
+      <th>User name</th>
       <th>Caption</th>
+      <th>Created_at</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -10,8 +12,9 @@
   <tbody>
     <% @posts.each do |post| %>
       <tr>
-        <td><%= post.caption %></td>
-        <td><%= link_to 'Show', post %></td>
+        <td><%= post.user.name %></td>
+        <td><%= link_to(post.caption, post, {class: "linkcolor"}) %></td>
+        <td><%= post.created_at %></td>
         <td><%= link_to 'Edit', edit_post_path(post) %></td>
         <td><%= link_to 'Destroy', post, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,5 +1,7 @@
 <section class="section">
   <div class="container">
+    <div class="columns is-mobile is-vcentered">
+      <div class="column is-half is-offset-one-quarter">
     <p>
       <% if @post.photos.attached? %>
         <% @post.photos.each do |photo| %>
@@ -19,7 +21,13 @@
       <strong>Address:</strong>
       <%= @post.spot.address %>
     </p>
+    <!-- コメントの投稿フォーム -->
+    <%= render 'comments/form', { post: @post, comment: @comment } %>
+    <!-- 投稿されたコメントの表示エリア -->
+    <%= render 'comments/comments', { comments: @comments } %>
     <%= link_to 'Edit', edit_post_path(@post) %> |
     <%= link_to 'Back', posts_path %>
+    </div> 
+    </div>
   </div>
 </section>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -18,7 +18,7 @@
           <button class="button is-dark"><%= link_to('edit profile', edit_profile_path, class: 'linkwhite') %></button>
         </div>
         <div class="has-text-centered mt-2">
-          <%= link_to('退会', users_path(current_user), { method: :delete, data: { confirm: '退会してもよろしいですか?' }, class: 'linkcolor'}) %>
+          <%= link_to('退会', user_path(current_user), { method: :delete, data: { confirm: '退会してもよろしいですか?' }, class: 'linkcolor'}) %>
         </div>
       </div> 
     </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -2,6 +2,7 @@ ja:
   activerecord:
     models:
       user: 'ユーザー'
+      comment: 'コメント'
     attributes:
       user:
         name: 'ニックネーム'
@@ -10,3 +11,5 @@ ja:
         password_confirmation: 'パスワード（確認）'
       post:
         photos: '画像ファイル'
+      comment:
+        body: 'コメント'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -42,3 +42,7 @@ ja:
       fail: '投稿に失敗しました'  
     index:
       title: photos    
+  comments:
+    create:
+      success: 'コメントの投稿が完了しました'
+      fail: 'コメントの投稿に失敗しました'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
 
-  resources :posts
+  resources :posts do
+    resources :comments, only: %i[create], shallow: true
+  end
   resources :spots, only: %i[index]
   resources :users, only: %i[new create destroy]
   resource  :profile, only: %i[show edit update]

--- a/db/migrate/20220112062621_create_comments.rb
+++ b/db/migrate/20220112062621_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :comments do |t|
+      t.text :body, null: false
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_07_121745) do
+ActiveRecord::Schema.define(version: 2022_01_12_062621) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,16 @@ ActiveRecord::Schema.define(version: 2022_01_07_121745) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.text "body", null: false
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "posts", force: :cascade do |t|
@@ -75,6 +85,8 @@ ActiveRecord::Schema.define(version: 2022_01_07_121745) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
   add_foreign_key "posts", "users"
   add_foreign_key "spots", "posts"
 end


### PR DESCRIPTION
## 概要
- commentモデルとcommentsコントローラーを作成し、
投稿詳細画面にコメントの投稿フォームと投稿されたコメントの表示エリアを追加しました。
- コメント未入力と65535文字超の場合は、バリデーションエラーが発生するようにしています。
- コメントの投稿に成功した場合は、「コメントの投稿が完了しました」と表示され、
コメントの投稿に失敗した際は、「コメントの投稿に失敗しました」と表示されます。
- コメントと投稿内容は、新しいものが一番上に表示されるように並び替えをしました。
- コメントを投稿したユーザーが退会をすると、そのユーザーが投稿したコメントは削除されるようにしています。
- コメントをした人がcurrent_userの場合は、編集ボタンと削除ボタンが表示されるようになっています。
（コメントの投稿者がcurrent_userではない場合は、編集ボタンと削除ボタンは表示されません。）

## 確認方法
- モデルを追加したので `bundle exec rails db:migrate` を実行してください
- rails serverを起動して、ブラウザ上で上記の点をご確認ください。

## チェックリスト
- [x] Lint のチェックをパスした

## コメント
コメントの表示部分はバランスが少しおかしいので、あとから修正するかもしれません。