### PR TITLE
Fix: 未ログインの状態でも投稿一覧画面と投稿詳細画面にアクセスできるように修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,8 @@
 class PostsController < ApplicationController
+  skip_before_action :require_login, only: %i[index show]
+
   def index
-    # @posts = Post.all.order(created_at: :desc)
+    # N+1問題解消のため、postsテーブルからデータを取得する際に、関連するusersテーブルのデータも取得する。
     @posts = Post.includes(:user).order(created_at: :desc)
   end
 

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -7,7 +7,7 @@
         <strong><%= comment.user.name %></strong>
         <%= simple_format(comment.body) %>
         <small>
-          <% if current_user.own?(comment) %>
+          <% if logged_in? && current_user.own?(comment) %>
             <%= link_to("#", { method: :get, class: 'linkcolor' }) do %>
               <%= icon 'fa', 'pen' %>
             <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -15,7 +15,7 @@
         <td><%= post.user.name %></td>
         <td><%= link_to(post.caption, post, {class: "linkcolor"}) %></td>
         <td><%= post.created_at %></td>
-        <% if current_user.own?(post) %>
+        <% if logged_in? && current_user.own?(post) %>
           <td>
             <%= link_to(edit_post_path(post), { method: :get, class: 'linkcolor' }) do %>
               <%= icon 'fa', 'pen' %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -21,7 +21,7 @@
                 <%= @post.caption %>
                 <br>
                 <small>
-                  <% if current_user.own?(@post) %>
+                  <% if logged_in? && current_user.own?(@post) %>
                     <%= link_to(edit_post_path(@post), { method: :get, class: 'linkcolor' }) do %>
                       <%= icon 'fa', 'pen' %>
                     <% end %>
@@ -40,11 +40,14 @@
           </div>
         </article>
         <!-- コメントの投稿フォーム -->
+        
         <article class="media">
           <figure class="media-left">
           </figure>
           <div class="media-content">
-            <%= render 'comments/form', { post: @post, comment: @comment } %>
+            <% if logged_in? %>
+              <%= render 'comments/form', { post: @post, comment: @comment } %>
+            <% end %>
           </div>
         </article>
       </div>


### PR DESCRIPTION
## 概要
- posts_controllerにskip_before_action :require_login, only: %i[index show]を追加して、
indexとshowアクションのみ未ログイン状態でもアクセスできるようにしました。
- postsのindexとshowのビューにあったif current_user.own?(post)の記述を
if logged_in? && current_user.own?(post)に変更して、ログインしているかどうかも判定できるようにしました。
- postsのshowのビューで、コメントフォームは未ログイン状態では表示されないように修正しました。

## 確認方法
rails serverを起動して、ログインをしていない状態で以下の挙動をご確認ください。
- ヘッダーのバグちゃんのアイコンから投稿一覧画面にアクセスができる。
- 投稿一覧画面のキャプションをクリックすると、投稿詳細画面にアクセスができる。
- 投稿詳細画面では、投稿されたコメントは見られるが、投稿フォームは表示されない。

## チェックリスト
- [x] Lint のチェックをパスした