### PR TITLE
Add: コメント投稿機能の非同期通信対応。

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,11 +1,7 @@
 class CommentsController < ApplicationController
   def create
-    comment = current_user.comments.build(comment_params)
-    if comment.save
-      redirect_to post_path(comment.post), success: t('.success')
-    else
-      redirect_to post_path(comment.post), danger: t('.fail')
-    end
+    @comment = current_user.comments.build(comment_params)
+    @comment.save
   end
 
   private

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -9,11 +9,8 @@
         <small>
           <%= comment.created_at.strftime("%Y-%m-%d %H:%M") %>
           <% if logged_in? && current_user.own?(comment) %>
-            <%= link_to("#", { method: :get, class: 'linkcolor' }) do %>
-              <%= icon 'fa', 'pen' %>
-            <% end %>
-            <%= link_to("#", { method: :delete, data: { confirm: '削除してよろしいですか？' }, class: 'linkcolor' }) do %>
-              <%= icon 'fas', 'trash' %>
+            <%= link_to '#', class: 'js-delete-comment-button', method: :delete, data: { confirm: '削除しますか？' }, class: 'linkcolor', remote: true do %>
+              <%= icon 'fa', 'trash' %>
             <% end %>
           <% end %>
         </small>

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -1,1 +1,3 @@
-<%= render comments %>
+<div id="js-table-comment">
+  <%= render comments %>
+</div>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,7 +1,6 @@
-<%= form_with model: comment, url: [post, comment], local: true do |f| %>
-<%= render 'shared/error_messages', object: f.object %>
+<%= form_with model: comment, url: [post, comment], id: 'new_comment' do |f| %>
   <div class="field">
-    <%= f.text_area :body, class: 'textarea', placeholder: "コメントを追加…" %>
+    <%= f.text_area :body, class: 'textarea', id: 'js-new-comment-body', placeholder: "コメントを追加…" %>
   </div>
   <div>
     <%= f.submit (t 'defaults.register'), class: 'button is-dark' %>

--- a/app/views/comments/create.js.erb
+++ b/app/views/comments/create.js.erb
@@ -1,0 +1,7 @@
+$("#error_messages").remove()
+<% if @comment.errors.present? %>
+  $("#new_comment").prepend("<%= j(render('shared/error_messages', object: @comment)) %>")
+<% else %>
+  $("#js-table-comment").prepend("<%= j(render('comments/comment', comment: @comment)) %>")
+  $("#js-new-comment-body").val('')
+<% end %>


### PR DESCRIPTION
## 概要
コメントを投稿する機能を同期通信から非同期通信に変更する対応をしました。

## 確認方法
rails serverを起動して、コメントの投稿機能が画面遷移せずに行えるかご確認ください。

## コメント
コメントの削除機能の非同期通信対応は別のIssuesで行います。