### PR TITLE
Add: 投稿された住所から経度と緯度を取得。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,10 +29,13 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'active_storage_validations'
 gem 'bulma-rails'
-gem 'dotenv-rails'
 gem 'font-awesome-sass'
 gem 'rails-i18n'
 gem 'sorcery'
+
+# Google Map関連
+gem 'dotenv-rails'
+gem 'geocoder' # 住所から緯度経度を算出する。
 
 group :development, :test do
   # Debugger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,7 @@ GEM
     ffi (1.15.4)
     font-awesome-sass (5.15.1)
       sassc (>= 1.11)
+    geocoder (1.7.3)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.8.11)
@@ -347,6 +348,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   font-awesome-sass
+  geocoder
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (~> 3.2)

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,3 +1,8 @@
 class Spot < ApplicationRecord
   belongs_to :post
+
+  # addressカラムを基準に緯度経度を算出する。
+  geocoded_by :address
+  # 住所変更時に緯度経度も変更する。
+  after_validation :geocode
 end

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,4 @@
+Geocoder.configure(
+  lookup: :google,
+  api_key: ENV['API_KEY']
+)


### PR DESCRIPTION
## 概要
- gem 'geocoder'を追加
- config/initializers/geocoder.rbのファイルを生成
- 上記ファイルに、GoogleのGeocoding APIを使用するための記述を追加
- spot.rbに、addressカラムを基準に緯度経度を算出するための記述と住所変更時に緯度経度も変更されるような記述を追加

## 確認方法
- Gem を追加したので `bundle install` を実行してください
- rails consoleで経度緯度の値が入っていることをご確認ください。

## チェックリスト
- [x] Lint のチェックをパスした

## コメント
mapにピンを立てるなどの実装は別のIssuesで対応予定です。
