### PR TITLE
Add: 投稿フォームで画像のプレビューが表示されるようした

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -59,7 +59,15 @@ hr {
   color: #FFFFFF;
 }
 
+// mapのスタイル
 #map {
   height: 600px;
   width: 1345px;
+}
+
+// 投稿画面のプレビュー画像のサイズ指定とプレビュー画像を横並びに配置する指定
+#preview {
+  max-height: 200px;
+  max-width: 100px;
+  display: flex;
 }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,5 @@
 class Post < ApplicationRecord
-  validates :photos, attached: { message: 'を選択してください。' }
+  validates :photos, attached: { message: 'を選択してください。' }, limit: { min: 1, max: 3 }
 
   belongs_to :user
   # postのレコードを削除したときに紐付いていたspotを同時に削除

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -2,9 +2,13 @@
 <%= render 'shared/error_messages', object: f.object %>
   <div class="field">
     <%= f.label :photos, class: 'label', class: 'has-text-weight-light' %><br>
-    <%= f.file_field :photos, direct_upload: true, multiple: true %>
-    <p class="help is-info">必須</p>
+    <%= f.file_field :photos, class: "push", multiple: true, onchange: "loadImage(this);" %>
+    <p class="help is-info">必須(3枚まで)</p>
   </div>
+  <div id="post_images" style="display: none;">
+    <p id="preview"></p>
+  </div>
+  <%= render "loadimage" %>
   <div class="field">
     <%= f.fields_for :spot do |s| %>
       <%= s.label :address, class: 'label', class: 'has-text-weight-light' %>

--- a/app/views/posts/_loadimage.html.erb
+++ b/app/views/posts/_loadimage.html.erb
@@ -10,7 +10,7 @@
     for (i = 0; i < obj.files.length; i++) {
         let fileReader = new FileReader();
         fileReader.onload = (function (e) {
-            var img = new Image();
+            let img = new Image();
             img.src = e.target.result;
             document.getElementById('preview').appendChild(img);
         });

--- a/app/views/posts/_loadimage.html.erb
+++ b/app/views/posts/_loadimage.html.erb
@@ -1,0 +1,20 @@
+<script>
+  function loadImage(obj)
+  {
+    let allPreview = document.getElementById('post_images');
+    let newPreview = document.createElement("p");
+    allPreview.querySelector("p").remove();
+    newPreview.setAttribute("id","preview");
+    allPreview.insertBefore(newPreview, allPreview.firstChild);
+    document.getElementById("post_images").style.display = "";
+    for (i = 0; i < obj.files.length; i++) {
+        let fileReader = new FileReader();
+        fileReader.onload = (function (e) {
+            var img = new Image();
+            img.src = e.target.result;
+            document.getElementById('preview').appendChild(img);
+        });
+      fileReader.readAsDataURL(obj.files[i]);
+    }
+  }
+</script>


### PR DESCRIPTION
## 概要
- 投稿フォームに画像のプレビューが表示されるようにしました
- 投稿できる画像の枚数を最大3枚に変更しました

## 確認方法
<img width="1438" alt="スクリーンショット 2022-01-27 23 02 27" src="https://user-images.githubusercontent.com/72340915/151373884-de53d5f8-b755-4115-b609-a19dc4656200.png">
rails serverを起動のうえ、/posts/newにアクセスして、ご確認ください。

## チェックリスト
- [x] Lint のチェックをパスした