### PR TITLE
Add: 写真一覧ページを作成。

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -72,7 +72,28 @@ hr {
   display: flex;
 }
 
-// 背景を白くしたいページで使用
+// 静的なページで背景を白するため指定
 #backcolor {
   background-color: #FFF;
+}
+
+// 写真一覧ページの写真部分のCSS指定
+figure {
+  position: relative;
+  display: flex;
+  flex-flow: column;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+// 写真一覧ページのキャプション部分のCSS指定
+figcaption {
+  position: absolute;
+  width: 100%;
+  transform: translate(0, -108%);
+  background-color:  rgba(0, 0, 0, .5);
+  color: #fff;
+  padding: 10px;
+  text-align: center;
+  margin: 0;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,9 @@
     <% end %>
     <hr>
     <%= render 'shared/flash_message' %>
+    <main>
     <%= yield %>
+    </main>
     <hr>
     <%= render 'shared/footer' %>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,10 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/css/lightbox.css" rel="stylesheet">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/js/lightbox.min.js" type="text/javascript"></script>
+
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application' %>
     <link href="https://fonts.googleapis.com/css2?family=Zen+Maru+Gothic&display=swap" rel="stylesheet">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,41 +1,17 @@
 <% content_for(:title, t('.title')) %>
 <div class="container">
-<table>
-  <thead>
-    <tr>
-      <th>User name</th>
-      <th>Caption</th>
-      <th>Address</th>
-      <th>Created_at</th>
-      <th colspan="3"></th>
-    </tr>
-  </thead>
-
-  <tbody>
+  <figure>
     <% @posts.each do |post| %>
-      <tr>
-        <td><%= post.user.name %></td>
-        <td><%= link_to(post.caption, post, {class: "linkcolor"}) %></td>
-        <td><%= post.spot.address %></td>
-        <td><%= post.created_at %></td>
-        <% if logged_in? && current_user.own?(post) %>
-          <td>
-            <%= link_to(edit_post_path(post), { method: :get, class: 'linkcolor' }) do %>
-              <%= icon 'fa', 'pen' %>
-            <% end %>
-          </td>
-          <td>
-            <%= link_to(post, { method: :delete, data: { confirm: '削除してよろしいですか？' }, class: 'linkcolor' })do %>
-              <%= icon 'fas', 'trash' %>
-            <% end %>
-          </td>
-        <% end %>  
-      </tr>
+      <% post.photos.each do |photo| %>
+        <%= link_to post do %>
+          <%= image_tag(photo) %>
+          <figcaption>
+            <%= post.caption %><br>
+            <i class="far fa-user"></i>
+            <%= post.user.name %>
+          </figcaption>
+        <% end %>
+      <% end %>
     <% end %>
-  </tbody>
-</table>
-
-<br>
-
-<%= link_to 'New Post', new_post_path %>
+  </figure>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -11,7 +11,10 @@
               <p>
                 <% if @post.photos.attached? %>
                   <% @post.photos.each do |photo| %>
-                    <%= image_tag photo.variant(resize_to_limit: [300, 200]) %>
+                    <!-- クリックした写真を拡大する -->
+                    <%= link_to photo, "data-lightbox" => photo do %>
+                      <%= image_tag photo.variant(resize_to_limit: [300, 200]), :style=>"width:300;" %>
+                    <% end %>
                   <% end %>
                 <% end %>
               </p>


### PR DESCRIPTION
## 概要
- 投稿された写真のみの一覧ページを作成。
- 投稿詳細ページで写真をクリックした時に拡大される機能を追加。

## 確認方法
rails serverを起動して、ブラウザ上で動作をご確認ください。
<img width="1439" alt="スクリーンショット 2022-02-05 22 25 45" src="https://user-images.githubusercontent.com/72340915/152644245-27c64ae3-31c8-4702-bf2f-bee66749c063.png">
<img width="1436" alt="スクリーンショット 2022-02-05 22 26 55" src="https://user-images.githubusercontent.com/72340915/152644261-68fe5fe3-74c2-4722-9827-088db0f53550.png">
<img width="1440" alt="スクリーンショット 2022-02-05 22 34 11" src="https://user-images.githubusercontent.com/72340915/152644320-da444700-455e-4180-8d80-d6d00c51e87a.png">
<img width="1440" alt="スクリーンショット 2022-02-05 22 35 05" src="https://user-images.githubusercontent.com/72340915/152644324-f59ca113-58a9-4b9e-adf9-43282380428f.png">

## チェックリスト
- [x] Lint のチェックをパスした

## コメント
投稿時、住所は空欄でも投稿できるようにしていますが、
住所なしの投稿があると地図自体が表示できなくなってしまうため、
住所の投稿も必須にしようか検討しています。
